### PR TITLE
Fix #10: Fix cell positioning in visualization - use lower-left corne…

### DIFF
--- a/visualize.py
+++ b/visualize.py
@@ -98,9 +98,9 @@ def plot_fabric_layout(fabric_cells_path: str, pins_path: str, output_path: str)
             y = slot['y']
             
             # Draw semi-transparent rectangle for each slot
-            # Center the rectangle at the slot coordinates
+            # Coordinates are already the lower-left corner (DEF PLACED origin)
             slot_rect = patches.Rectangle(
-                (x - width_um/2, y - height_um/2),
+                (x, y),
                 width_um, height_um,
                 linewidth=0.1, edgecolor='black', facecolor=color, alpha=0.5
             )


### PR DESCRIPTION
The coordinates in fabric_cells.yaml are the lower-left corner (as stated in position_semantics: die-absolute, DEF PLACED origin (lower-left)), but the code was treating them as centers and subtracting half the width/height, which created gaps.
The fix changes the rectangle position from (x - width_um/2, y - height_um/2) to (x, y), so cells are placed directly at their specified coordinates with no gaps.